### PR TITLE
Fix: reponse writer bug where the reponse.Write() method would set th…

### DIFF
--- a/json.go
+++ b/json.go
@@ -26,11 +26,11 @@ func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 		w.WriteHeader(500)
 		return
 	}
+
+	w.WriteHeader(code)
 	_, err = w.Write(dat)
 	if err != nil {
 		log.Printf("Error writting response: %s", err)
-		w.WriteHeader(500)
 		return
 	}
-	w.WriteHeader(code)
 }


### PR DESCRIPTION
…e return code and prevent any future changes, making a 201 response impossible